### PR TITLE
Friendler Dockerfile

### DIFF
--- a/Container Samples/Java RESTful Engine/Dockerfile
+++ b/Container Samples/Java RESTful Engine/Dockerfile
@@ -1,17 +1,18 @@
-# Grab Alpine Linux base image
-FROM alpine:latest as base
+# Grab Tomcat image
+FROM tomcat:9.0.71-jdk8-corretto
 
-# Add necessary tools
-RUN apk update
-RUN apk upgrade
-RUN apk add --no-cache bash
-RUN apk add --no-cache openjdk8
+# Let Docker know that Tomcat will be exposing port 8888
+# Do not forget to map out to something useful (-p 8888:8080)
+EXPOSE 8888
 
-# Copy the tomcat installation over to the /opt directory, and set as working directory
-COPY ./ /opt
+# Copy the Engine files inside the container
+# You can get these files here: https://www.windwardstudios.com/version/version-downloads
+COPY App_Data /usr/local/tomcat/webapps/
+# Do not forget to tweak to the version you are downloading
+COPY JavaRESTfulEngine-22.4.2.2.pom /usr/local/tomcat/webapps/
+COPY ROOT.war /usr/local/tomcat/webapps/
 
-# Replace VERSION_NUMBER below to match the version of tomcat that you are using (Ex:apache-tomcat-9.0.56)
-WORKDIR /opt/apache-tomcat-VERSION_NUMBER
-
+# Change the workdir to where Tomcat is installed
+WORKDIR /usr/local/tomcat
 # Set the container to start the Tomcat Server when launched, and sleep so that the container doesn't exit afterwards
 ENTRYPOINT ./bin/catalina.sh start && sleep infinity


### PR DESCRIPTION
since Tomcat has their own Docker image, we could be using it directly.

this PR also lets Docker know about which port Tomcat wants to expose (8888), and adds instructions on how the Java RESTful Engine can go inside the image.